### PR TITLE
Fix HTML5 parsing errors

### DIFF
--- a/tasks/coco_crowd_labeling.html
+++ b/tasks/coco_crowd_labeling.html
@@ -97,6 +97,7 @@
 
     </script>
   </head>
+  <body>
   <form id='mturk_form' action="MTURK_FORM_TO_SUBMIT">
     <input type="hidden" id="hitId" name="hitId" value='MTURK_HIT_ID'>
     <input type="hidden" id="assignmentId" name="assignmentId" value='MTURK_ASSIGNMENT_ID'>
@@ -105,8 +106,6 @@
     <input type="hidden" id="ans" name="ans" value=''>
     <input type="hidden" id="duration" name="duration" value='0'>
   </form>
-  <body>
-
 
   <div class="modal hide fade" style="width:800px">
     <div class="modal-header">
@@ -155,7 +154,7 @@
       </span>
 
       <canvas id="canvas-img" style="display:none"></canvas>
-      <div id="container"style='margin-top:3px'></div>
+      <div id="container" style='margin-top:3px'></div>
       <div id="container-invisible"></div>
 
     </div>


### PR DESCRIPTION
When ran ```python create_hit.py``` with  "tasks/coco_crowd_labeling.html," I got this error:
```
create HIT on sandbox
Traceback (most recent call last):
  File "/home2/grad97/myh/git/coco-ui/create_hit.py", line 60, in <module>
    Question = create_xml_question(html_text),
  File "/usr/lib/python2.7/site-packages/botocore/client.py", line 324, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/lib/python2.7/site-packages/botocore/client.py", line 622, in _make_api_call
    raise error_class(parsed_response, operation_name)
ClientError: An error occurred (ParameterValidationError) when calling the CreateHIT operation: There was an error parsing the HTML5 data in your request.  Please make sure the data is well-formed and validates as HTML5. Details: Errors: <! [109,8] An \u201cbody\u201d start tag seen but an element of the same type was already open. !> <! [159,26] No space between attributes. !> Invalid content: 
<!DOCTYPE html>
<html lang="en">
  <head>
...
```
After fixing the bugs in coco_crowd_labeling.html, ```python create_hit.py``` runs successfully.